### PR TITLE
Patch Proxmox VM Module

### DIFF
--- a/proxmox/vm/main.tf
+++ b/proxmox/vm/main.tf
@@ -17,7 +17,7 @@ resource "proxmox_virtual_environment_vm" "vm_resource" {
 
   agent {
     # read 'Qemu guest agent' section, change to true only when ready
-    enabled = var.enable_guest_agent
+    enabled = true
     # timeout = "15m"
     # trim    = false
     # type    = "virtio"
@@ -108,8 +108,12 @@ resource "proxmox_virtual_environment_file" "cloud_config" {
     chpasswd:
       list: |
         ${var.username}:${var.temp_user_password}
+    timezone: ${var.timezone}
+    packages:
+      - qemu-guest-agent
     runcmd:
       - timedatectl set-timezone ${var.timezone}
+      - systemctl enable qemu-guest-agent --now
       - echo "done" > /tmp/cloud-config.done
     EOF
 

--- a/proxmox/vm/variables.tf
+++ b/proxmox/vm/variables.tf
@@ -36,12 +36,6 @@ variable "temp_user_password" {
   description = "Temorary login password. Upon the first login, a prompt to change the password will be presented."
 }
 
-variable "enable_guest_agent" {
-  default     = false
-  type        = bool
-  description = "Whether to enable the QEMU guest agent. The `qemu-guest-agent` must be installed **and** running. Read the 'Qemu guest agent' section [in bpg/proxmox docs](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_vm#qemu-guest-agent) first."
-}
-
 variable "cores" {
   default     = 1
   type        = number

--- a/proxmox/vm/versions.tf
+++ b/proxmox/vm/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "bpg/proxmox"
-      version = "0.70.0"
+      version = "~> 0.83.2"
     }
     local = {
       source  = "hashicorp/local"

--- a/proxmox/vm/versions.tf
+++ b/proxmox/vm/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = "~> 1.13.1"
   required_providers {
     proxmox = {
       source  = "bpg/proxmox"


### PR DESCRIPTION
This PR:
- Bakes the QEMU guest agent into the VM cloud init rather than relying on user installation for quicker provider/proxmox management.
- Upgrades provider version.
- Upgrades Terraform version.